### PR TITLE
Avoid usage of undeclared variable.

### DIFF
--- a/TypedFastBitSet.js
+++ b/TypedFastBitSet.js
@@ -73,7 +73,7 @@ TypedFastBitSet.prototype.flip = function(index) {
 // Remove all values, reset memory usage
 TypedFastBitSet.prototype.clear = function() {
   this.count = 0 | 0;
-  this.words = new Uint32Array(count);
+  this.words = new Uint32Array(this.count);
 };
 
 // Set the bit at index to false


### PR DESCRIPTION
count is undefined in that context. It is still converted to 0 by browser, but in case of this source code is passed through ES lint or typescript compilation that ends up with error.