### PR TITLE
Range functions for bitset

### DIFF
--- a/TypedFastBitSet.js
+++ b/TypedFastBitSet.js
@@ -84,6 +84,48 @@ TypedFastBitSet.prototype.remove = function(index) {
   this.words[index  >>> 5] &= ~(1 << index);
 };
 
+// Set bits from start (inclusive) to end (exclusive)
+TypedFastBitSet.prototype.addRange = function (start, end) {
+  if (start >= end) {
+    return;
+  }
+
+  if ((this.count << 5) <= end) {
+    this.resize(end);
+  }
+
+  var firstword = start >> 5;
+  var endword = (end - 1) >> 5;
+
+  if (firstword === endword) {
+    this.words[firstword] |= (~0 << start) & (~0 >>> -end);
+    return;
+  }
+  this.words[firstword] |= ~0 << start;
+  this.words.fill(~0, firstword + 1, endword);
+  this.words[endword] |= ~0 >>> -end;
+};
+
+// Remove bits from start (inclusive) to end (exclusive)
+TypedFastBitSet.prototype.removeRange = function (start, end) {
+  start = Math.min(start, (this.count << 5) - 1);
+  end = Math.min(end, (this.count << 5) - 1);
+
+  if (start >= end) {
+    return;
+  }
+  var firstword = start >> 5;
+  var endword = (end - 1) >> 5;
+
+  if (firstword === endword) {
+    this.words[firstword] &= ~((~0 << start) & (~0 >>> -end));
+    return;
+  }
+  this.words[firstword] &= ~(~0 << start);
+  this.words.fill(0, firstword + 1, endword);
+  this.words[endword] &= ~(~0 >>> -end);
+};
+
 // Return true if no bit is set
 TypedFastBitSet.prototype.isEmpty = function(index) {
   var c = this.count;

--- a/unit/basictests.js
+++ b/unit/basictests.js
@@ -144,4 +144,53 @@ describe('BitSet', function() {
     if (!arraysEquals(a, a2)) throw 'bad values';
   });
 
+  it('Testing addRange/removeRange', function () {
+    var b1 = new TypedFastBitSet();
+    b1.addRange(0, 1);
+    if (!b1.has(0)) throw 'bad value';
+    if (b1.size() != 1) throw 'bad size';
+
+    b1.addRange(32, 64);
+    for (var i = 32; i < 64; ++i) {
+      if (!b1.has(i)) throw 'bad value';
+    }
+
+    if (b1.size() != 33) throw 'bad size';
+
+    b1.addRange(64, 129);
+    for (var i = 63; i < 129; ++i) {
+      if (!b1.has(i)) throw 'bad value';
+    }
+
+    if (b1.size() != 98) throw 'bad size';
+
+    for (var i = 0; i < 256; ++i) {
+      for (var j = i - 1; j < 256; ++j) {
+        var bb = new TypedFastBitSet();
+        bb.addRange(i, j);
+        for (var k = 0; k < 256 + 32; ++k) {
+          if (bb.has(k) !== (k >= i && k < j)) throw 'bad value';
+        }
+        if (j > 0 && bb.count > (j << 5)) throw 'bad count';
+      }
+    }
+
+    var b2 = new TypedFastBitSet();
+    b2.addRange(0, 193);
+    b2.remove(0);
+    b2.remove(63);
+    b2.remove(128);
+    b2.trim();
+
+    for (var i = 0; i < 256; ++i) {
+      for (var j = i - 1; j < 256; ++j) {
+        var bb = b2.clone();
+        bb.removeRange(i, j);
+        for (var k = 0; k < 256 + 32; ++k) {
+          if (bb.has(k) !== (b2.has(k) && !(k >= i && k < j))) throw 'bad value';
+        }
+      }
+    }
+  });
+
 });


### PR DESCRIPTION
This PR will add addRange/deleteRange functions for bitset. 

I think there is an advantage from Uint32Array.fill intrinsic calls, but maybe it should be benchmarked against plain js implementation.

The code is borrowed from RoaringBitmap and slightly adapted.
Tests are over-exhaustive for now, but runs in ~250ms on my laptop.