### PR TITLE
Add missing typing for fromWords

### DIFF
--- a/TypedFastBitSet.d.ts
+++ b/TypedFastBitSet.d.ts
@@ -4,6 +4,11 @@
 
 
 declare class TypedFastBitSet {
+    /**
+     * Returns a new TypedFastBitset given a Uint32Array of words
+     */
+    static fromWords(words: Uint32Array): TypedFastBitSet;
+
     constructor(iterable?: number[]);
 
     /** Add the value (Set the bit at `index` to `true`) */


### PR DESCRIPTION
This simply adds a typing for am method that was missing.