### PR TITLE
Iteration perf improvements

### DIFF
--- a/benchmark/issue25.js
+++ b/benchmark/issue25.js
@@ -14,9 +14,13 @@ function ForEachBench() {
   console.log("starting forEach benchmark");
   const tb = new TypedFastBitSet();
   const stb = new SparseTypedFastBitSet();
+  const tb_small = new TypedFastBitSet();
 
   const s = new Set();
   for (let i = 0; i < N; i++) {
+    if (i < 100) {
+      tb_small.add(i);
+    }
     tb.add(smallgap * i + 5);
     stb.add(smallgap * i + 5);
   }
@@ -24,36 +28,58 @@ function ForEachBench() {
   const suite = new Benchmark.Suite();
   // add tests
   const ms = suite
-  .add("TypedFastBitSet-forof", function () {
-    let card = 0;
-    for (const element of stb) {
-      card++;
-    }
-    return card;
-  })
-  .add("TypedFastBitSet-foreach", function () {
-    let card = 0;
-    const inc = function () {
-      card++;
-    };
-    tb.forEach(inc);
-    return card;
-  })
-  .add("SparseTypedFastBitSet-forof", function () {
-    let card = 0;
-    for (const element of stb) {
-      card++;
-    }
-    return card;
-  })
-  .add("SparseTypedFastBitSet-foreach", function () {
-    let card = 0;
-    const inc = function () {
-      card++;
-    };
-    tb.forEach(inc);
-    return card;
-  })
+    .add("TypedFastBitSet-forof", function () {
+      let card = 0;
+      for (const element of stb) {
+        card++;
+      }
+      return card;
+    })
+    .add("TypedFastBitSet-foreach", function () {
+      let card = 0;
+      const inc = function () {
+        card++;
+      };
+      tb.forEach(inc);
+      return card;
+    })
+    .add("SparseTypedFastBitSet-forof", function () {
+      let card = 0;
+      for (const element of stb) {
+        card++;
+      }
+      return card;
+    })
+    .add("SparseTypedFastBitSet-foreach", function () {
+      let card = 0;
+      const inc = function () {
+        card++;
+      };
+      tb.forEach(inc);
+      return card;
+    })
+    .add("TypedFastBitSet-nested-forof", function () {
+      let card = 0;
+      for (const x of tb_small) {
+        for (const y of tb_small) {
+          for (const z of tb_small) {
+            card += x + y + z;
+          }
+        }
+      }
+      return card;
+    })
+    .add("TypedFastBitSet-nested-forEach", function () {
+      let card = 0;
+      tb_small.forEach(function (x) {
+        tb_small.forEach(function (y) {
+          tb_small.forEach(function (z) {
+            card += x + y + z;
+          });
+        });
+      });
+      return card;
+    })
     // add listeners
     .on("cycle", function (event) {
       console.log(String(event.target));
@@ -61,7 +87,6 @@ function ForEachBench() {
     // run async
     .run({ async: false });
 }
-
 
 const main = function () {
   console.log(

--- a/src/SparseTypedFastBitSet.ts
+++ b/src/SparseTypedFastBitSet.ts
@@ -545,27 +545,57 @@ export class SparseTypedFastBitSet implements BitSet {
   /**
    * Iterator of set bit locations (values)
    */
-  *[Symbol.iterator](): IterableIterator<number> {
+  [Symbol.iterator](): IterableIterator<number> {
     if (this.arraySize === -1) {
       const words = this.data;
       const c = words.length;
-      for (let k = 0; k < c; ++k) {
-        let w = words[k];
-        while (w != 0) {
-          const t = w & -w;
-          yield (k << 5) + hammingWeight((t - 1) | 0);
-          w ^= t;
-        }
-      }
+      let k = 0;
+      let w = words[k];
+
+      return {
+        [Symbol.iterator]() {
+          return this;
+        },
+        next() {
+          while (k < c) {
+            if (w !== 0) {
+              const t = w & -w;
+              const value = (k << 5) + hammingWeight((t - 1) | 0);
+              w ^= t;
+              return { done: false, value };
+            } else {
+              k++;
+              if (k < c) {
+                w = words[k];
+              }
+            }
+          }
+          return { done: true, value: undefined };
+        },
+      };
     } else {
       const array = this.data;
-      for (let i = 0; i < this.arraySize; i++) {
-        const v = array[i];
-        yield v;
-        if (v !== array[i]) {
-          i--;
-        }
-      }
+      const arraySize = this.arraySize;
+      let i = 0;
+
+      return {
+        [Symbol.iterator]() {
+          return this;
+        },
+        next() {
+          if (i < arraySize) {
+            const v = array[i];
+            const result = { done: false, value: v };
+            if (v !== array[i]) {
+              i--;
+            }
+            i++;
+            return result;
+          } else {
+            return { done: true, value: undefined };
+          }
+        },
+      };
     }
   }
 

--- a/src/TypedFastBitSet.ts
+++ b/src/TypedFastBitSet.ts
@@ -265,17 +265,33 @@ export class TypedFastBitSet implements BitSet {
   /**
    * Iterator of set bit locations (values)
    */
-  *[Symbol.iterator](): IterableIterator<number> {
+  [Symbol.iterator](): IterableIterator<number> {
     const words = this.words;
     const c = words.length;
-    for (let k = 0; k < c; ++k) {
-      let w = words[k];
-      while (w != 0) {
-        const t = w & -w;
-        yield (k << 5) + hammingWeight((t - 1) | 0);
-        w ^= t;
-      }
-    }
+    let k = 0;
+    let w = words[k];
+
+    return {
+      [Symbol.iterator]() {
+        return this;
+      },
+      next() {
+        while (k < c) {
+          if (w !== 0) {
+            const t = w & -w;
+            const value = (k << 5) + hammingWeight((t - 1) | 0);
+            w ^= t;
+            return { done: false, value };
+          } else {
+            k++;
+            if (k < c) {
+              w = words[k];
+            }
+          }
+        }
+        return { done: true, value: undefined };
+      },
+    };
   }
 
   /**


### PR DESCRIPTION
Here are two commits that drastically improve the performance of using `TypedFastBitSet` and `SparseTypedFastBitSet` in `for..of` loops.

Just to explain: `*[Symbol.iterator]()` implementations, while terse, leverage JavaScript generators which are notably slower than just returning a plain iterator object. This is because generators also support coroutines, which aren't being leveraged at all here.

I'm making this PR because our team is favoring `forEach` over `for..of` for performance reasons, and if the point of this type is to make things fast, I think it should be fast in all cases. `forEach(fn)`, in particular when used in a nested fashion, don't perform as well as in-lined for loops. :) 

Thank you for this library BTW!